### PR TITLE
fix: 관리자페이지 유튜브 링크 파라미터 수정

### DIFF
--- a/apps/admin/src/api/youtube.ts
+++ b/apps/admin/src/api/youtube.ts
@@ -3,7 +3,6 @@ import {
   IPostYoutubeResponse,
 } from "@/types/youtube/response";
 import { api } from ".";
-import { headers } from "next/headers";
 
 // FIXME: YoutubeType은 packages/types로 빼야함
 export type YoutubeType = "youtube" | "shorts" | "live";

--- a/apps/admin/src/api/youtube.ts
+++ b/apps/admin/src/api/youtube.ts
@@ -3,6 +3,7 @@ import {
   IPostYoutubeResponse,
 } from "@/types/youtube/response";
 import { api } from ".";
+import { headers } from "next/headers";
 
 // FIXME: YoutubeType은 packages/types로 빼야함
 export type YoutubeType = "youtube" | "shorts" | "live";
@@ -19,11 +20,12 @@ export const getYoutubeLink = async (type: YoutubeType) => {
 };
 
 export const postYoutubeLink = async ({ id, type }: IPostFetcherProps) => {
-  const { data } = await api.post<IPostYoutubeResponse>("/api/youtube", {
-    params: {
-      id,
-      type,
-    },
-  });
+  const { data } = await api.post<IPostYoutubeResponse>(
+    "/api/youtube",
+    {},
+    {
+      params: { id, type },
+    }
+  );
   return data;
 };

--- a/apps/admin/src/components/youtube.tsx
+++ b/apps/admin/src/components/youtube.tsx
@@ -15,32 +15,42 @@ interface IYoutubeSectionProps {
 const YoutubeSection = ({ title, type }: IYoutubeSectionProps) => {
   const { data: youtubeLink } = useGetYoutubeLink(type);
   const { register, handleSubmit, setValue } = useForm<IYoutubeForm>();
-
   const { mutate } = usePostYoutubeLink(type);
+
+  const extractVideoId = (url: string) => {
+    const regExp =
+      /^.*(youtu.be\/|v\/|u\/\w\/|shorts\/|live\/|watch\?v=|&v=)([^#&?]*).*/;
+    const match = url.match(regExp);
+
+    return match && match[2].length === 11 ? match[2] : null;
+  };
 
   const onSubmit = (data: IYoutubeForm) => {
     const { youtube, shorts, live } = data;
-    const id = youtube || shorts || live;
+    const url = youtube || shorts || live;
+    const id = extractVideoId(url);
 
-    mutate(
-      {
-        id,
-      },
-      {
-        onSuccess: ({ result }) =>
-          result === "success"
-            ? alert("변경되었습니다.")
-            : alert("API 요청 중 오류가 발생하였습니다."),
-        onError: (error) => console.log(error),
-      }
-    );
+    id
+      ? mutate(
+          {
+            id,
+          },
+          {
+            onSuccess: ({ result }) => {
+              setValue(type, "");
+              return result === "success"
+                ? alert("변경되었습니다.")
+                : alert("API 요청 중 오류가 발생하였습니다.");
+            },
+            onError: (error) => console.log(error),
+          }
+        )
+      : alert("유튜브 링크를 다시 확인해주세요.");
   };
 
-  useEffect(() => {
-    if (youtubeLink) {
-      setValue(type, youtubeLink);
-    }
-  }, [youtubeLink]);
+  const onInValid = () => {
+    alert("유튜브 링크는 필수입니다. 입력해주세요.");
+  };
 
   return (
     <div className="flex flex-col justify-center items-center">
@@ -54,9 +64,18 @@ const YoutubeSection = ({ title, type }: IYoutubeSectionProps) => {
           {youtubeLink}
         </a>
       </div>
-      <form onSubmit={handleSubmit(onSubmit)} className="mt-4">
+      <div>
+        <iframe
+          className="h-full w-full rounded-lg"
+          src={`https://www.youtube.com/embed/${youtubeLink}`}
+          allowFullScreen
+        />
+      </div>
+      <form onSubmit={handleSubmit(onSubmit, onInValid)} className="mt-4">
         <input
-          {...register(type)}
+          {...register(type, {
+            required: true,
+          })}
           className="border rounded px-4 py-2 text-black"
         />
         <button className="bg-blue-500 text-white px-4 py-2 rounded mt-2">

--- a/packages/firebase/src/database.ts
+++ b/packages/firebase/src/database.ts
@@ -20,7 +20,6 @@ interface IPostYoutubeProps extends IGetYoutubeProps {
 
 const database = getFirestore(firebase);
 
-// TODO: 유튜브 아이디 추출함수 추가해야 함
 export const getYoutubeLink = async ({ videoType }: IGetYoutubeProps) => {
   const getQuery = query(
     collection(database, videoType),


### PR DESCRIPTION
## 수정

- 관리자페이지 유튜브 링크 수정시, 파라미터가 `type`만 전송되는 오류발생
- `body`로 전송되는 부분을 `params` 부분으로 전송될 수 있게 수정
- 관리자페이지 유튜브 링크 수정시, 유튜브링크(라이브/일반/쇼츠)에서 아이디만 추출하도록 수정

## 참고

- https://stackoverflow.com/questions/21607808/convert-a-youtube-video-url-to-embed-code
