### PR TITLE
chore: 운영서버 주보이미지업로드 안되는 에러 수정

### DIFF
--- a/apps/admin/src/api/index.ts
+++ b/apps/admin/src/api/index.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
 
 export const api = axios.create({
-  baseURL: process.env.AXIOS_DEFAULT_BASEURL,
+  baseURL: process.env.NEXT_PUBLIC_AXIOS_DEFAULT_BASEURL,
 });

--- a/apps/admin/src/pages/api/cloudflare/index.ts
+++ b/apps/admin/src/pages/api/cloudflare/index.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { api } from "@/api";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default async function handler(
@@ -17,7 +17,7 @@ export default async function handler(
         data: {
           result: { uploadURL },
         },
-      } = await axios.post(`${process.env.CLOUDFLARE_REQ_URL}`, null, {
+      } = await api.post(`${process.env.CLOUDFLARE_REQ_URL}`, null, {
         headers: {
           ContentType: "application/json",
           Authorization: `Bearer ${process.env.CLOUDFLARE_API_KEY}`,


### PR DESCRIPTION
## 수정

- 테스트서버에서는 업로드가 잘되는데 운영서버에서는 업로드가 안되는 에러 발생
- CloudFlare 이미지업로드 URL을 못받아오는 걸로 생각하여 못받아왔을 경우, 500 에러 발생시킴
- `axios` 키워드를 그대로 쓰고 있는 코드 수정

## 참고

-
