### PR TITLE
Refactor/bulletin

### DIFF
--- a/apps/admin/src/pages/api/bulletins/index.ts
+++ b/apps/admin/src/pages/api/bulletins/index.ts
@@ -106,12 +106,6 @@ export default async function handler(
 
         const images = await Promise.all(promiseImages);
 
-        // CloudFlare 이미지를 base64로 변환
-        const buffers = images.map(async (image) => {
-          const { base64 } = await getBlurImage(`${image}/bulletin`);
-          return base64;
-        });
-
         // TODO: error 기능 추가
         if (!fields.date?.[0] || !fields.title?.[0])
           return new NextResponse("");
@@ -120,7 +114,6 @@ export default async function handler(
           date: fields.date?.[0],
           title: fields.title?.[0],
           images,
-          buffers: await Promise.all(buffers),
         });
 
         return result;

--- a/apps/client/src/components/news/bulletins/Modal.tsx
+++ b/apps/client/src/components/news/bulletins/Modal.tsx
@@ -4,12 +4,12 @@ import { useState } from "react";
 import { Spinner } from "ui";
 
 const BulletinModal = ({ selectedBulletinId }: { selectedBulletinId?: string }) => {
-  const { data } = useGetBulletin({ bulletinId: selectedBulletinId as string });
+  const { data, isLoading } = useGetBulletin({ bulletinId: selectedBulletinId as string });
   const bulletin = data?.bulletin;
   const [currentViewImage, setCurrentViewImage] = useState(0);
 
   // FIXME: 호출하기까지 시간이 걸리므로 임시로 로딩처리
-  if (!bulletin)
+  if (isLoading)
     return (
       <div className="flex h-[220px] w-[338px] items-center justify-center sm:h-[300px] sm:w-[468px] md:h-[440px] md:w-[688px] lg:h-[550px] lg:w-[868px]">
         <Spinner />

--- a/apps/client/src/components/news/bulletins/Modal.tsx
+++ b/apps/client/src/components/news/bulletins/Modal.tsx
@@ -1,13 +1,20 @@
-import BlurImageComponent from "@/components/blurImage";
 import { useGetBulletin } from "@/query/bulletin";
+import Image from "next/image";
 import { useState } from "react";
+import { Spinner } from "ui";
 
 const BulletinModal = ({ selectedBulletinId }: { selectedBulletinId?: string }) => {
   const { data } = useGetBulletin({ bulletinId: selectedBulletinId as string });
-
   const bulletin = data?.bulletin;
-
   const [currentViewImage, setCurrentViewImage] = useState(0);
+
+  // FIXME: 호출하기까지 시간이 걸리므로 임시로 로딩처리
+  if (!bulletin)
+    return (
+      <div className="flex h-[220px] w-[338px] items-center justify-center sm:h-[300px] sm:w-[468px] md:h-[440px] md:w-[688px] lg:h-[550px] lg:w-[868px]">
+        <Spinner />
+      </div>
+    );
 
   return (
     <div className="flex flex-col gap-2">
@@ -15,10 +22,12 @@ const BulletinModal = ({ selectedBulletinId }: { selectedBulletinId?: string }) 
       <div className="relative h-[220px] w-[338px] sm:h-[300px] sm:w-[468px] md:h-[440px] md:w-[688px] lg:h-[550px] lg:w-[868px]">
         {bulletin && (
           <a href={`${bulletin.images[currentViewImage]}/bulletin`} target="_blank">
-            <BlurImageComponent
-              img={`${bulletin.images[currentViewImage]}/bulletin`}
-              alt={`${bulletin.title}_${currentViewImage}`}
-              fill
+            <Image
+              src={`${bulletin.images[currentViewImage]}/bulletin`}
+              fill={true}
+              alt={bulletin.title}
+              placeholder="blur"
+              blurDataURL={`${bulletin.images[currentViewImage]}/blur`}
             />
           </a>
         )}

--- a/packages/type/src/bulletin.ts
+++ b/packages/type/src/bulletin.ts
@@ -6,14 +6,12 @@ export interface IBulletin {
   date: string;
   title: string;
   images: string[];
-  buffers: string[];
 }
 
 export interface IBulletinForm {
   date: string;
   title: string;
   images: string[];
-  buffers: string[];
 }
 
 export interface IBulletinImageForm extends Omit<IBulletinForm, "images"> {


### PR DESCRIPTION
## 수정

- 사용자페이지에서 주보 BlurImageComponent 사용하지않고 Cloudflare에서 제공하는 blur이미지로 `blurDataURL`을 설정해보았습니다.
- 또한 로딩시간이 있다고 판단되어 로딩처리도 하였습니다.
- 관리자페이지에서 주보 이미지를 업로드한 이후, base64로 변환하는 과정과 함께 base64 데이터를 DB에 저장하는 로직이 있었는데, Cloudflare에서 제공하는 blur이미지를 사용하기 때문에 필요가 없어져서 해당 부분 삭제하였습니다.

## 참고

-
