### PR TITLE
chore: Netlify 시크릿 스캔 기능 disable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+SECRETS_SCAN_SMART_DETECTION_ENABLED = "false"


### PR DESCRIPTION
## 수정

- 빌드실패로인한 Netlify Secret Scan 기능 disable

## 참고

-
